### PR TITLE
Lägger till MIC-43: Lägg till metod för att hämta olistad media från …

### DIFF
--- a/src/test/java/com/michelangelo/usermicroservice/services/TopTenRecommendedMediaServiceTest.java
+++ b/src/test/java/com/michelangelo/usermicroservice/services/TopTenRecommendedMediaServiceTest.java
@@ -2,6 +2,8 @@ package com.michelangelo.usermicroservice.services;
 
 import com.michelangelo.usermicroservice.VO.GenreVO;
 import com.michelangelo.usermicroservice.VO.MediaVO;
+import com.michelangelo.usermicroservice.entities.MediaUser;
+import com.michelangelo.usermicroservice.repositories.MediaUserRepository;
 import com.michelangelo.usermicroservice.entities.StreamHistory;
 import com.michelangelo.usermicroservice.repositories.StreamHistoryRepository;
 import org.junit.jupiter.api.Test;
@@ -15,6 +17,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -22,6 +25,8 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 public class TopTenRecommendedMediaServiceTest {
 
+    @Mock
+    private MediaUserRepository mediaUserRepository;
     @Mock
     private StreamHistoryRepository streamHistoryRepository;
 
@@ -31,41 +36,41 @@ public class TopTenRecommendedMediaServiceTest {
     @InjectMocks
     private TopTenRecommendedMediaService topTenRecommendedMediaService;
 
+
     @Test
     public void shouldReturnUnlistenedMediaByGenres() {
         // Given
         Long userId = 1L;
         List<Integer> genreIds = Arrays.asList(1, 2);
 
-        // Skapa testdata
+        // Skapa testdata för StreamHistory
         List<StreamHistory> streamHistories = Arrays.asList(
-                new StreamHistory(1L, 1, 10),
-                new StreamHistory(2L, 2, 5)
+                new StreamHistory(1L, 1, 10), // Lyssnat på media med ID 1
+                new StreamHistory(2L, 2, 5)   // Lyssnat på media med ID 2
         );
         when(streamHistoryRepository.findByMediaUser_Id(userId)).thenReturn(streamHistories);
 
+        // Skapa genrer
         GenreVO rockGenre = new GenreVO();
         rockGenre.setId(1L);
         rockGenre.setName("Rock");
-        rockGenre.setCount(0);
 
         GenreVO popGenre = new GenreVO();
         popGenre.setId(2L);
         popGenre.setName("Pop");
-        popGenre.setCount(0);
 
+        // Skapa media med olika genrer
         MediaVO rockMedia = new MediaVO();
-        rockMedia.setId(3L);
+        rockMedia.setId(3L);  // Nytt media som användaren inte har lyssnat på
         rockMedia.setTitle("Rock Song");
-        rockMedia.setReleaseDate(LocalDate.of(2023, 1, 1));
         rockMedia.setGenres(List.of(rockGenre));
 
         MediaVO popMedia = new MediaVO();
-        popMedia.setId(4L);
+        popMedia.setId(4L);  // Nytt media som användaren inte har lyssnat på
         popMedia.setTitle("Pop Song");
-        popMedia.setReleaseDate(LocalDate.of(2023, 1, 2));
         popMedia.setGenres(List.of(popGenre));
 
+        // Simulera API-anrop för att hämta media baserat på genrer
         when(restTemplate.getForObject("http://MEDIAMICROSERVICE/media/genre/1", MediaVO[].class))
                 .thenReturn(new MediaVO[]{rockMedia});
         when(restTemplate.getForObject("http://MEDIAMICROSERVICE/media/genre/2", MediaVO[].class))
@@ -75,8 +80,66 @@ public class TopTenRecommendedMediaServiceTest {
         List<MediaVO> result = topTenRecommendedMediaService.findUnlistenedMediaByGenres(userId, genreIds);
 
         // Then
-        assertEquals(2, result.size());
-        assertTrue(result.stream().anyMatch(media -> media.getId().equals(3L)));
-        assertTrue(result.stream().anyMatch(media -> media.getId().equals(4L)));
+        assertEquals(2, result.size()); // Endast två media eftersom de är olyssnade
+        assertTrue(result.stream().anyMatch(media -> media.getId().equals(3L))); // Rock Song
+        assertTrue(result.stream().anyMatch(media -> media.getId().equals(4L))); // Pop Song
+        assertFalse(result.stream().anyMatch(media -> media.getId().equals(1L))); // Media användaren redan lyssnat på ska inte vara med
+        assertFalse(result.stream().anyMatch(media -> media.getId().equals(2L))); // Media användaren redan lyssnat på ska inte vara med
+    }
+
+    @Test
+    public void shouldReturnUnlistenedMediaFromOtherGenres() {
+        // Given
+        Long userId = 1L;
+        List<Integer> excludeGenreIds = Arrays.asList(1, 2); // Exkludera genre IDs 1 och 2
+
+        // Mocka StreamHistory för användaren
+        List<StreamHistory> userStreamHistory = Arrays.asList(
+                new StreamHistory(1L, 1, 10), // Lyssnat på media med ID 1
+                new StreamHistory(2L, 2, 5)   // Lyssnat på media med ID 2
+        );
+        when(streamHistoryRepository.findByMediaUser_Id(userId)).thenReturn(userStreamHistory);
+
+        // Mocka alla genrer från Media-mikrotjänsten
+        GenreVO rockGenre = new GenreVO();
+        rockGenre.setId(1L);
+        rockGenre.setName("Rock");
+
+        GenreVO popGenre = new GenreVO();
+        popGenre.setId(2L);
+        popGenre.setName("Pop");
+
+        GenreVO classicalGenre = new GenreVO();
+        classicalGenre.setId(3L);
+        classicalGenre.setName("Classical");
+
+        GenreVO hiphopGenre = new GenreVO();
+        hiphopGenre.setId(4L);
+        hiphopGenre.setName("Hip Hop");
+
+        GenreVO[] allGenres = new GenreVO[]{rockGenre, popGenre, classicalGenre, hiphopGenre};
+        when(restTemplate.getForObject("http://MEDIAMICROSERVICE/genres", GenreVO[].class)).thenReturn(allGenres);
+
+        // Mocka media från genrer som inte är exkluderade (Classical och Hip Hop)
+        MediaVO classicalMedia = new MediaVO();
+        classicalMedia.setId(3L);
+        classicalMedia.setTitle("Classical Song");
+
+        MediaVO hiphopMedia = new MediaVO();
+        hiphopMedia.setId(4L);
+        hiphopMedia.setTitle("Hip Hop Song");
+
+        when(restTemplate.getForObject("http://MEDIAMICROSERVICE/media/genre/3", MediaVO[].class))
+                .thenReturn(new MediaVO[]{classicalMedia});
+        when(restTemplate.getForObject("http://MEDIAMICROSERVICE/media/genre/4", MediaVO[].class))
+                .thenReturn(new MediaVO[]{hiphopMedia});
+
+        // When
+        List<MediaVO> result = topTenRecommendedMediaService.findUnlistenedMediaFromOtherGenres(userId, excludeGenreIds);
+
+        // Then
+        assertEquals(2, result.size()); // Det bör finnas två media från andra genrer
+        assertTrue(result.contains(classicalMedia)); // Verifiera att "Classical Song" är med i resultatet
+        assertTrue(result.contains(hiphopMedia)); // Verifiera att "Hip Hop Song" är med i resultatet
     }
 }


### PR DESCRIPTION
…andra genrer och uppdatera topp 10-logik

- Implementera indUnlistenedMediaFromOtherGenres för att få media från genrer utanför de tre mest spelade.
- Uppdatera getTopTenRecommendedMedia för att inkludera 2 media från andra genrer och returnera totalt 10 rekommenderade media.